### PR TITLE
Make puppeteer a peer dep, and upgrade to 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
   },
   "dependencies": {
     "debug": "^2.3.3",
-    "generic-pool": "^3.1.4",
-    "puppeteer": "^0.10.2"
+    "generic-pool": "^3.1.4"
+  },
+  "peerDependencies": {
+    "puppeteer": "^1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,13 @@ const initPuppeteerPool = ({
   // specifies the maximum number of times a resource can be reused before being destroyed
   maxUses = 50,
   testOnBorrow = true,
-  puppeteerArgs = [],
+  puppeteerArgs = {},
   validator = () => Promise.resolve(true),
   ...otherConfig
 } = {}) => {
   // TODO: randomly destroy old instances to avoid resource leak?
   const factory = {
-    create: () => puppeteer.launch(...puppeteerArgs).then(instance => {
+    create: () => puppeteer.launch(puppeteerArgs).then(instance => {
       instance.useCount = 0
       return instance
     }),


### PR DESCRIPTION
It would be nice if users could provide their own puppeteer dependency so they can stay on the latest Chrome.

They changed the launch function to take an object instead of a list so I fixed that as well.